### PR TITLE
tversky_ext_profile.py: Simplify convert_date()

### DIFF
--- a/tversky_ext_profile.py
+++ b/tversky_ext_profile.py
@@ -8,7 +8,6 @@ import psutil
 from collections import Counter
 from datetime import datetime, timedelta
 from operator import itemgetter
-from time import mktime, strptime
 from tqdm import tqdm
 
 class ExtendedCounter(Counter):
@@ -231,7 +230,7 @@ def print_recall(recall_top):
         print("%f" % (float(recall_top[n])))
 
 def convert_date(date_as_string):
-    return datetime.fromtimestamp(mktime(strptime(date_as_string[:-3], "%Y-%m-%d %H:%M:%S.%f")))
+    return datetime.strptime(date_as_string[:-3], "%Y-%m-%d %H:%M:%S.%f")
 
 def change_id_ext(last, current):
     half_life = 2500 


### PR DESCRIPTION
Instead of going through the time.strptime() -> time.mktime() ->
datetime.fromtimestamp(), use datetime.strptime() directly.

Incidentally, this fixes the issue with revfinder's android.json
dataset, where the value of '1900-01-01 08:00:00.00000...' for
"grant_date" key in one of entries caused the script to crash
in convert_date() with the following error message:

```
Traceback (most recent call last):
  File ".\tversky_ext_profile.py", line 259, in <module>
    users = parse_file(f)
  File ".\tversky_ext_profile.py", line 164, in parse_file
    last_date = reviewers_last_date.get(hist['userId'], convert_date(hist['grant_date']) - timedelta(days=1))
  File ".\tversky_ext_profile.py", line 234, in convert_date
    return datetime.fromtimestamp(mktime(strptime(date_as_string[:-3], "%Y-%m-%d %H:%M:%S.%f")))
OverflowError: mktime argument out of range
```